### PR TITLE
Match readme instructions

### DIFF
--- a/challenge.html
+++ b/challenge.html
@@ -12,7 +12,7 @@
 
 <body>
   <div class="m5">
-    <p>Please sort these numbers in descending order:</p>
+    <p>Please sort these numbers in ascending order:</p>
     <p class="numbers">10,3,1,2,5,9</p>
     <form>
       <input type="text" class="input" placeholder="Enter your answer" name="answer" required="">


### PR DESCRIPTION
In the README we say to have them sort the numbers in "ascending" order but here we're saying "descending". I don't think it matters which one we change but they should be the same unless we're doing this on purpose for some reason.